### PR TITLE
Fix token chown stacktrace (SOFTWARE-4372)

### DIFF
--- a/register.py
+++ b/register.py
@@ -56,7 +56,7 @@ def parse_args():
     parser.add_argument(
         "--local-dir",
         default=None,
-        help="Full path to the user's local working directory outside of the container.",
+        help="Full path to the user's local token directory outside of the container.",
     )
 
     args = parser.parse_args()

--- a/register.py
+++ b/register.py
@@ -121,6 +121,12 @@ def is_admin():
         return ctypes.windll.shell32.IsUserAnAdmin() == 0
 
 
+NONROOT_TOKEN_MSG = '''"Registration not run as root; to use token:"
+  1. Copy token to the system tokens directory: cp "{path}" /etc/condor/tokens.d/
+  2. Ensure the token is owned by HTCondor: chown condor: /etc/condor/tokens.d/{name}
+'''
+
+
 def request_token(pool, resource, local_dir=None):
     if ":" in pool:
         alias, port = pool.split(":")
@@ -167,10 +173,7 @@ def request_token(pool, resource, local_dir=None):
     logger.debug("Corrected token file permissions...")
     print("Token was written to {}".format(msg_path))
     if not is_admin():
-        print("Registration not run as root; to use token:")
-        print("  1. Copy token to the system tokens directory: cp \"{}\" /etc/condor/tokens.d/".format(token_path))
-        print("  2. Ensure the token is owned by HTCondor: chown condor: /etc/condor/tokens.d/{}".format(token_name))
-        
+        print(NONROOT_TOKEN_MSG.format(path=msg_path, name=token_name))
 
     return True
 

--- a/registry/connect/views.py
+++ b/registry/connect/views.py
@@ -37,7 +37,7 @@ def docker():
     sources = get_sources(user_info)
 
     install_commands = {
-        source: "docker run -v $PWD/tokens:/etc/condor/tokens.d opensciencegrid/open-science-pool-registry:fresh register.py --local-dir $PWD --host {}".format(
+        source: "docker run -v $PWD/tokens:/etc/condor/tokens.d opensciencegrid/open-science-pool-registry:fresh register.py --local-dir $PWD/tokens --host {}".format(
             source
         )
         for source in sources


### PR DESCRIPTION
We modified the token path to improve messages in the container use case but missed that we needed it for `chown` inside of the container.

```
Token request approved!
Traceback (most recent call last):
  File "/usr/bin/register.py", line 323, in <module>
    main()
  File "/usr/bin/register.py", line 105, in main
    success = request_token(pool=args.pool, resource=args.host, local_dir=args.local_dir)
  File "/usr/bin/register.py", line 158, in request_token
    shutil.chown(token_path, user=TOKEN_OWNER_USER, group=TOKEN_OWNER_GROUP)
  File "/usr/lib64/python3.6/shutil.py", line 1052, in chown
    os.chown(path, _user, _group)
FileNotFoundError: [Errno 2] No such file or directory: '/home/blin/50-flock.openscienceghosted-ce-chtc-ubuntu.osg.chtc.io-registration'
Error: Encountered unhandled error: [Errno 2] No such file or directory: '/home/blin/50-fnsciencegrid.org-hosted-ce-chtc-ubuntu.osg.chtc.io-registration'
```