### PR TITLE
Fixup token fetching CLI

### DIFF
--- a/registry/connect/views.py
+++ b/registry/connect/views.py
@@ -37,7 +37,8 @@ def docker():
     sources = get_sources(user_info)
 
     install_commands = {
-        source: "docker run --rm -v $PWD/tokens:/etc/condor/tokens.d " +
+        source: "mkdir tokens && \\" +
+                "docker run --rm -v $PWD/tokens:/etc/condor/tokens.d " +
                 f"opensciencegrid/open-science-pool-registry:fresh register.py --local-dir $PWD/tokens --host {source}"
         for source in sources
     }

--- a/registry/connect/views.py
+++ b/registry/connect/views.py
@@ -37,9 +37,8 @@ def docker():
     sources = get_sources(user_info)
 
     install_commands = {
-        source: "docker run -v $PWD/tokens:/etc/condor/tokens.d opensciencegrid/open-science-pool-registry:fresh register.py --local-dir $PWD/tokens --host {}".format(
-            source
-        )
+        source: "docker run --rm -v $PWD/tokens:/etc/condor/tokens.d " +
+                f"opensciencegrid/open-science-pool-registry:fresh register.py --local-dir $PWD/tokens --host {source}"
         for source in sources
     }
 

--- a/registry/connect/views.py
+++ b/registry/connect/views.py
@@ -37,7 +37,7 @@ def docker():
     sources = get_sources(user_info)
 
     install_commands = {
-        source: "mkdir tokens && \\" +
+        source: "mkdir -p tokens && \\" +
                 "docker run --rm -v $PWD/tokens:/etc/condor/tokens.d " +
                 f"opensciencegrid/open-science-pool-registry:fresh register.py --local-dir $PWD/tokens --host {source}"
         for source in sources


### PR DESCRIPTION
`register.py` is used by admins to generate and fetch tokens for resources that they've registered. I don't want to dump the tokens into the user's cwd but we need to make sure that the `tokens` dir exists