### PR TITLE
Review documentation (SOFTWARE-4847)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ found in some of the subdirectories of `registry/`.
 Blueprints:
 - `index` - landing page, "about" page, etc.
 - `account` - handles user accounts. We don't quite have registration because we use CILogon, but this is where you can go to see (for example) your contact email.
-- `signup` - handles forms for users to register themselves and their data sources.
-- `connect` - provides instructions for users to install and connect their data sources.
+- `signup` - handles forms for users to register themselves and their resources.
+- `connect` - provides instructions for users to install and connect their resources.
 - `token` - handles the server side of the token workflow when connecting a new data source.
 
 Each blueprint has its own `static` and `templates` directories, and there

--- a/registry/account/templates/account.html
+++ b/registry/account/templates/account.html
@@ -16,22 +16,25 @@
                     </p>
                     {% if sources %}
                         <p>
-                            Your registered data sources are
+                          You have the following resources 
+                          <a href="https://opensciencegrid.org/docs/common/registration/">registered</a>
+                          with the OSG:
                         </p>
                         <ul>
                             {% for source in sources %}
                                 <li>{{ source }}</li>
                             {% endfor %}
                         </ul>
+                        <a href="{{ url_for("connect.docker") }}" class="btn btn-info btn-lg">Get a Token</a>
                     {% else %}
                         <p>
-                            You have no registered sources.
+                            You have no registered resources.
                         </p>
                     {% endif %}
                 {% else %}
                     <p>
                         {% if user_info.get("name") %}
-                            You successfully with the following identity:
+                            You successfully logged in with the following identity:
                             <ul>
                                 <li>Name: {{ user_info.get("name") }}</li>
                                 {% if user_info.get("idp") %}

--- a/registry/connect/templates/docker.html
+++ b/registry/connect/templates/docker.html
@@ -10,7 +10,7 @@
     <div class="container">
         <div class="row">
             <div class="col">
-                <h1>Connect a New Docker Worker Node</h1>
+                <h1>Connect New Services to the Open Science Pool</h1>
 
                 {% include "no-sources-warning.html" %}
 
@@ -22,7 +22,7 @@
                 <ol>
                     <li>
                         Installation requires a container runtime (such as Docker or podman) and the ability to launch containers.
-                        Typically, this requires root (administrator) access on the host.
+                        For Docker, this requires typically requires root (administrator) access on the host.
                     </li>
                     <li>
                         {% if not sources %}

--- a/registry/connect/templates/docker.html
+++ b/registry/connect/templates/docker.html
@@ -22,7 +22,7 @@
                 <ol>
                     <li>
                         Installation requires a container runtime (such as Docker or podman) and the ability to launch containers.
-                        For Docker, this requires typically requires root (administrator) access on the host.
+                        For Docker, this typically requires root (administrator) access on the host.
                     </li>
                     <li>
                         {% if not sources %}

--- a/registry/connect/templates/install-commands.html
+++ b/registry/connect/templates/install-commands.html
@@ -19,15 +19,15 @@
     </div>
 {% else %}
     <div class="alert alert-danger" role="alert">
-        You don't have any registered data sources!
+        You don't have any registered resources!
     </div>
 {% endif %}
 <div class="alert alert-info" role="alert">
-    If you don't see a data source you expected to see,
+    If you don't see a resource that you expected to see,
     it most likely means that you are not listed as an
-    owner of that data source. Make sure you have
+    owner of that resource. Make sure you have
     <a href="https://opensciencegrid.org/docs/common/registration/">registered</a>
-    the data source. If you need to be listed as an owner
-    of a data source you did not originally register, please
+    the resource. If you need to be listed as an owner
+    of a resource you did not originally register, please
     {{ "contact us" | contact_us }}.
 </div>

--- a/registry/index/templates/index.html
+++ b/registry/index/templates/index.html
@@ -16,11 +16,16 @@
                     <p class="lead">
                         The Open Science Pool token service provides system administrators
                         with the ability to request and receive tokens necessary to authenticate
-                        worker node containers with the Open Science Pool.
+                        Access Points and worker node containers with the Open Science Pool.
                     </p>
 
                     <p class="lead">
-                        <a class="btn btn-primary" href="https://opensciencegrid.org/docs/resource-sharing/os-backfill-containers/">Learn More</a>
+                      <a class="btn btn-primary" href="https://opensciencegrid.org/docs/submit/osg-flock/">Learn More About Access Points</a>
+                      <a class="btn btn-primary" href="https://opensciencegrid.org/docs/resource-sharing/os-backfill-containers/">Learn More About Worker Node Containers</a>
+                    </p>
+
+                    <p>
+
                     </p>
                 </div>
             </div>
@@ -66,7 +71,7 @@
                         </p>
                     </div>
                     <div class="card-footer text-center">
-                        <a href="{{ url_for("connect.connect") }}" class="btn btn-primary btn-lg">Connect!</a>
+                        <a href="{{ url_for("connect.docker") }}" class="btn btn-primary btn-lg">Connect!</a>
                     </div>
                 </div>
             </div>

--- a/registry/index/templates/index.html
+++ b/registry/index/templates/index.html
@@ -23,10 +23,6 @@
                       <a class="btn btn-primary" href="https://opensciencegrid.org/docs/submit/osg-flock/">Learn More About Access Points</a>
                       <a class="btn btn-primary" href="https://opensciencegrid.org/docs/resource-sharing/os-backfill-containers/">Learn More About Worker Node Containers</a>
                     </p>
-
-                    <p>
-
-                    </p>
                 </div>
             </div>
         </div>

--- a/registry/index/templates/index.html
+++ b/registry/index/templates/index.html
@@ -16,12 +16,12 @@
                     <p class="lead">
                         The Open Science Pool token service provides system administrators
                         with the ability to request and receive tokens necessary to authenticate
-                        Access Points and worker node containers with the Open Science Pool.
+                        Access Points and Execution Point containers with the Open Science Pool.
                     </p>
 
                     <p class="lead">
                       <a class="btn btn-primary" href="https://opensciencegrid.org/docs/submit/osg-flock/">Learn More About Access Points</a>
-                      <a class="btn btn-primary" href="https://opensciencegrid.org/docs/resource-sharing/os-backfill-containers/">Learn More About Worker Node Containers</a>
+                      <a class="btn btn-primary" href="https://opensciencegrid.org/docs/resource-sharing/os-backfill-containers/">Learn More About Execution Point Containers</a>
                     </p>
                 </div>
             </div>

--- a/registry/templates/base.html
+++ b/registry/templates/base.html
@@ -44,7 +44,7 @@
 
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav mr-auto">
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('connect.connect') }}">Get a Token</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ url_for('connect.docker') }}">Get a Token</a></li>
                 </ul>
                 <ul class="navbar-nav">
                     <li class="nav-item"><a class="btn btn-info nav-item" href="{{ url_for('account.account_get') }}">Account</a></li>


### PR DESCRIPTION
1.  AP admins can also use the registry service, mention them wherever
    we talk about backfill containers
2.  Data sources -> resources, the latter is used all over
    opensciencegrid.org/docs
3.  Hide the connect page that differentiates between requesting
    tokens for Docker vs Kubernetes since we don't have users retrieve
    tokens differently between each setup.

Changes have been manually deployed to https://os-registry.osgdev.chtc.io/ if you want to take a look