### PR TITLE
Issue certificate for the syslog CA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 
 ARG IMAGE_BASE_TAG=release
 
-FROM opensciencegrid/software-base:3.5-el7-$IMAGE_BASE_TAG
+FROM opensciencegrid/software-base:3.6-el7-$IMAGE_BASE_TAG
 
 LABEL maintainer OSG Software <support@opensciencegrid.org>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN \
     yum clean all && rm -rf /var/cache/yum/*
 
 COPY registry run_local.sh requirements.txt /opt/registry/
-RUN pip3 install -r /opt/registry/requirements.txt
+RUN pip3 install -U pip && pip3 install -r /opt/registry/requirements.txt
 
 COPY register.py /usr/bin
 COPY supervisor-apache.conf /etc/supervisord.d/40-apache.conf

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -22,7 +22,7 @@ RUN \
     popd
 
 COPY registry run_local.sh requirements.txt /opt/registry/
-RUN pip3 install -r /opt/registry/requirements.txt
+RUN pip3 install -U pip && pip3 install -r /opt/registry/requirements.txt
 
 COPY register.py /usr/bin
 COPY supervisor-apache.conf /etc/supervisord.d/40-apache.conf

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -1,7 +1,7 @@
 
 ARG IMAGE_BASE_TAG=release
 
-FROM opensciencegrid/software-base:$IMAGE_BASE_TAG
+FROM opensciencegrid/software-base:3.6-el7-$IMAGE_BASE_TAG
 
 LABEL maintainer OSG Software <support@opensciencegrid.org>
 

--- a/examples/apache-template.conf
+++ b/examples/apache-template.conf
@@ -26,6 +26,8 @@
   WSGIDaemonProcess Registration display-name=Registration group=condor processes=2 threads=25 user=condor
   WSGIProcessGroup Registration
   WSGIScriptAlias / "/var/www/registration/wsgi.py"
+  # Authorization header is utilized internally by the CA handler.
+  WSGIPassAuthorization On
 
   ## OIDC configuration
   OIDCProviderMetadataURL https://cilogon.org/.well-known/openid-configuration

--- a/examples/apache.conf
+++ b/examples/apache.conf
@@ -76,6 +76,8 @@
   WSGIDaemonProcess Registration display-name=Registration group=condor processes=2 threads=25 user=condor home=/srv
   WSGIProcessGroup Registration
   WSGIScriptAlias / "/srv/wsgi.py"
+  # Authorization header is utilized internally by the CA handler.
+  WSGIPassAuthorization On
 
   ## OIDC configuration
   OIDCProviderMetadataURL https://cilogon.org/.well-known/openid-configuration

--- a/registry/app.py
+++ b/registry/app.py
@@ -6,10 +6,11 @@ from .index import index_bp
 from .connect import install_bp
 from .token import token_bp
 from .account import account_bp
+from .ca import ca_bp
 
 from .template_filters import contact_us
 
-BLUEPRINTS = [index_bp, install_bp, token_bp, account_bp]
+BLUEPRINTS = [index_bp, install_bp, token_bp, account_bp, ca_bp]
 CONTEXT_PROCESSORS = []
 TEMPLATE_FILTERS = [contact_us]
 

--- a/registry/ca/__init__.py
+++ b/registry/ca/__init__.py
@@ -1,0 +1,1 @@
+from .views import ca_bp

--- a/registry/ca/views.py
+++ b/registry/ca/views.py
@@ -1,0 +1,98 @@
+
+import datetime
+import socket
+
+from flask import current_app, Blueprint, jsonify, request, make_response
+
+from ..exceptions import ConfigurationError
+
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes, serialization
+
+import cryptography.x509 as x509
+
+import htcondor
+
+ca_bp = Blueprint(
+    "ca",
+    __name__,
+)
+
+
+def get_ca_cert_key():
+
+    ca_filename = current_app.config.get("CA_CERTFILE", "/etc/pki/rsyslog/ca.pem")
+    cakey_filename = current_app.config.get("CA_KEYFILE", "/etc/pki/rsyslog/cakey.pem")
+
+    with open(ca_filename, "rb") as fp:
+        ca = x509.load_pem_x509_certificate(fp.read())
+
+    with open(cakey_filename, "rb") as fp:
+        cakey = serialization.load_pem_private_key(fp.read(), password=None)
+
+    return ca, cakey
+
+
+def ping_authz(token):
+    collector = current_app.config.get("COLLECTOR", "flock.opensciencegrid.org")
+    addrs = socket.getaddrinfo(collector, 9618, socket.AF_INET, socket.SOCK_STREAM)[0][-1]
+    myaddr = f"<{addrs[0]}:{addrs[1]}>"
+
+    with htcondor.SecMan() as secman:
+        secman.cm.setToken(htcondor.Token(token))
+        return secman.cm.ping(myaddr)
+
+@ca_bp.route("/ca", methods=["POST"])
+def connect():
+
+    authorization = request.headers.get("Authorization")
+    if not authorization:
+        return make_response(jsonify(err="Endpoint requires authorization"), 401)
+    authz_info = authorization.split()
+    if len(authz_info) != 2 or authz_info[0].strip().lower() != "bearer":
+        return make_response(jsonify(err="Endpoint requires bearer token"), 401)
+
+    try:
+        authz_info = ping_authz(authz_info[1].strip())
+
+        if authz_info.get("AuthMethods") != "TOKEN" or authz_info.get("Authentication") != "YES" or \
+                authz_info.get("AuthorizationSucceeded") != True or not authz_info.get("MyRemoteUserName"):
+            return make_response(jsonify(err="Remote authz server returned unexpected response"), 403)
+    except Exception as exc:
+        return make_response(jsonify(err="Failed to ping remote auth server", exc=str(exc)), 403)
+
+    form_csr = request.form.get("csr")
+    if not form_csr:
+        return make_response(jsonify(err="CSR request not provided"), 400)
+
+    try:
+        ca, cakey = get_ca_cert_key()
+    except Exception as exc:
+        return make_response(jsonify(err="Failed to load local key material", exc=str(exc)), 500)
+
+    try:
+        csr = x509.load_pem_x509_csr(form_csr.encode('utf-8'))
+    except Exception as exc:
+        return make_response(jsonify(err="Failed to parse provided CSR", exc=str(exc)), 400)
+
+    one_day = datetime.timedelta(1, 0, 0)
+
+    try:
+        username = authz_info.get("MyRemoteUserName")
+        builder = x509.CertificateBuilder(
+           ).subject_name(x509.Name([x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, username)])
+           ).issuer_name(ca.subject
+           ).not_valid_before(datetime.datetime.today() - one_day
+           ).not_valid_after(datetime.datetime.today() + (one_day * 30)
+           ).serial_number(x509.random_serial_number()
+           ).public_key(csr.public_key()
+           ).add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True
+           ).add_extension(x509.ExtendedKeyUsage([x509.oid.ExtendedKeyUsageOID.CLIENT_AUTH]), critical=True)
+
+        x509_obj = builder.sign(private_key=cakey, algorithm=hashes.SHA256())
+
+        return jsonify(x509=x509_obj.public_bytes(serialization.Encoding.PEM).decode())
+    except Exception as exc:
+        return make_response(jsonify(err="Internal error when building certificate", exc=str(exc)), 500)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 flask
 htcondor
+cryptography


### PR DESCRIPTION
This PR adds a simple API where, given a token and a CSR, a new certificate is returned.

The token is tested against the remote collector for validity.

The new certificate is signed by the logging CA with a CN equal to the subject name embedded in the token.