### PR TITLE
SOFTWARE-5916: EL9 Compatibility

### DIFF
--- a/registry/template_filters.py
+++ b/registry/template_filters.py
@@ -1,4 +1,6 @@
-from flask import Markup, current_app
+from flask import current_app
+from markupsafe import Markup
+
 
 
 def contact_us(text):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-flask
+flask==2.3.3
 htcondor
 cryptography

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-flask==2.3.3
+flask==3.0.3
 htcondor
 cryptography

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-flask==3.0.3
+flask==3.*
 htcondor
 cryptography

--- a/supervisor-apache.conf
+++ b/supervisor-apache.conf
@@ -1,5 +1,5 @@
 
 [program:httpd]
-command=/bin/bash -c "source /etc/sysconfig/httpd && exec /usr/sbin/httpd $OPTIONS -DFOREGROUND"
+command=/bin/bash -c "exec /usr/sbin/httpd $OPTIONS -DFOREGROUND"
 autorestart=true
 


### PR DESCRIPTION
- Remove `source /etc/sysconfig/httpd` from supervisorctl config since it's no longer provided in EL9
- Pin flask version to 3.0.3, fix deprecated `from flask import Markup` that broke between 2.3.3 and 3.0.3 (https://github.com/pallets/flask/pull/4996)