### PR TITLE
add logrotate & its cron job for log files in /var/log/httpd dir(test parameters)

### DIFF
--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -9,7 +9,7 @@ RUN \
     yum update -y && \
     (yum install -y git-core || yum install -y git) && \
     yum install -y --enablerepo=osg-upcoming condor && \
-    yum install -y python3-pip httpd mod_auth_openidc mod_ssl python3-mod_wsgi && \
+    yum install -y python3-pip httpd mod_auth_openidc mod_ssl python3-mod_wsgi logrotate && \
     yum install -y make && \
     yum clean all && rm -rf /var/cache/yum/*
 
@@ -28,8 +28,12 @@ RUN pip3 install -U pip && pip3 install -r /opt/registry/requirements.txt
 # Use our weird grid-security cert/key location
 RUN rm /etc/httpd/conf.d/ssl.conf
 
+# Setup cron job for logrotate to run every 5 minutes
+RUN crontab -l | { cat; echo "* * * * * /usr/sbin/logrotate /etc/logrotate.d/httpd >> /var/log/cron 2>&1"; } | crontab -
+
 COPY register.py /usr/bin
 COPY supervisor-apache.conf /etc/supervisord.d/40-apache.conf
+COPY logrotate-http.conf /etc/logrotate.d/httpd
 COPY examples/apache.conf /etc/httpd/conf.d/
 
 ENV CONFIG_DIR=/srv

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -28,8 +28,8 @@ RUN pip3 install -U pip && pip3 install -r /opt/registry/requirements.txt
 # Use our weird grid-security cert/key location
 RUN rm /etc/httpd/conf.d/ssl.conf
 
-# Setup cron job for logrotate to run every 5 minutes
-RUN crontab -l | { cat; echo "* * * * * /usr/sbin/logrotate /etc/logrotate.d/httpd >> /var/log/cron 2>&1"; } | crontab -
+# Setup cron job for logrotate to run as root every day  
+RUN echo "0 0 * * * root /usr/sbin/logrotate /etc/logrotate.d/httpd >> /var/log/cron 2>&1" > /etc/cron.d/logrotate-httpd  
 
 COPY register.py /usr/bin
 COPY supervisor-apache.conf /etc/supervisord.d/40-apache.conf

--- a/logrotate-http.conf
+++ b/logrotate-http.conf
@@ -1,0 +1,14 @@
+/var/log/httpd/*.log {
+    maxsize 10K
+    dateext
+    dateformat -%Y%m%d-%s
+    rotate 2
+    missingok
+    notifempty
+    compress
+    delaycompress
+    sharedscripts
+    postrotate
+        PID=$(pgrep -o httpd) && kill -USR1 $PID
+    endscript
+}

--- a/logrotate-http.conf
+++ b/logrotate-http.conf
@@ -1,14 +1,12 @@
 /var/log/httpd/*.log {
-    maxsize 10K
-    dateext
-    dateformat -%Y%m%d-%s
-    rotate 2
+    maxsize 100M  
+    rotate 20 
     missingok
     notifempty
     compress
     delaycompress
     sharedscripts
     postrotate
-        PID=$(pgrep -o httpd) && kill -USR1 $PID
+        PID=$(pgrep -o httpd); if [ "$PID" ]; then kill -USR1 $PID; fi 
     endscript
 }


### PR DESCRIPTION
Two files's change:
1. Dockerfile.testing: yum install logrotate, setup cron job for logrotate, copy logrotate-http.conf
2. logrotate-http.conf: setting for logrotate

Current setting for logrotate:
1. File Size Limit: limit each log file to **10 KB**.
2. Cron Job Frequency: The cron job is set to run **every minute** to check the log files in the /var/log/httpd directory.
3. Rotation Condition: When a log file reaches 10 KB, it is rotated and renamed with the current date and time suffix (-%Y%m%d-%s, second is included in the filename).
4. Retention Policy: allows only **two rotated logs** to exist at any time—**one compressed (`.gz`) and one regular**.

The next steps involve finalizing the settings for the file size limit, the frequency of log rotation, and the number of rotated logs to retain. Also, add changes to the Dockerfile if needed.