### PR TITLE
register.py: Do not chown token file in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,6 @@ COPY registry /srv/registry/
 
 ENV PYTHONUNBUFFERED=1
 ENV CONFIG_DIR=/srv
+ENV NO_CHOWN=1
 #ENTRYPOINT ["/opt/registry/run_local.sh"]
 #CMD ["--host=0.0.0.0"]

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -37,5 +37,6 @@ COPY logrotate-http.conf /etc/logrotate.d/httpd
 COPY examples/apache.conf /etc/httpd/conf.d/
 
 ENV CONFIG_DIR=/srv
+ENV NO_CHOWN=1
 #ENTRYPOINT ["/opt/registry/run_local.sh"]
 #CMD ["--host=0.0.0.0"]

--- a/register.py
+++ b/register.py
@@ -182,9 +182,10 @@ def request_token(pool, resource, scopes=None, local_dir=None):
 
     print("Token was written to {}".format(msg_path))
     if is_admin():
-        logger.debug("Correcting token file permissions...")
-        shutil.chown(token_path, user=TOKEN_OWNER_USER, group=TOKEN_OWNER_GROUP)
-        logger.debug("Corrected token file permissions...")
+        if not os.environ.get("NO_CHOWN"):
+            logger.debug("Correcting token file permissions...")
+            shutil.chown(token_path, user=TOKEN_OWNER_USER, group=TOKEN_OWNER_GROUP)
+            logger.debug("Corrected token file permissions...")
     else:
         print(NONROOT_TOKEN_MSG.format(path=msg_path, name=token_name))
 


### PR DESCRIPTION
Inside a container, chowning a token to the condor user generally creates a token that is not accessible by the user who ran the container.

This is especially true if user namespaces are used (e.g. with podman), since it will be chowned to one of the users' subuids, and they would have to `sudo` or `podman unshare` to chown it to something they can use.